### PR TITLE
Fix NPE thrown when userstore has no hash algorithm properties defined.

### DIFF
--- a/src/main/java/org/wso2/carbon/hash/provider/pbkdf2/ErrorMessage.java
+++ b/src/main/java/org/wso2/carbon/hash/provider/pbkdf2/ErrorMessage.java
@@ -31,8 +31,8 @@ public enum ErrorMessage {
             "Derived key length should be a positive integer"),
 
     // Server Errors.
-    ERROR_CODE_NO_SUCH_ALGORITHM("65001", "Not supported pseudo random function",
-            "PRF was not supported by Secret Key Factory"),
+    ERROR_CODE_NO_SUCH_ALGORITHM("65001", "Unsupported pseudo random function.",
+            "PRF: %s was not supported by Secret Key Factory."),
     ERROR_CODE_INVALID_KEY_SPEC("65002", "Secret key cannot be generated.",
             "Secret key cannot be generated from SecretKeyFactory"),
     ERROR_CODE_EMPTY_SALT_VALUE("65003", "Invalid salt value", "Salt value cannot be blank");

--- a/src/main/java/org/wso2/carbon/hash/provider/pbkdf2/PBKDF2HashProvider.java
+++ b/src/main/java/org/wso2/carbon/hash/provider/pbkdf2/PBKDF2HashProvider.java
@@ -56,6 +56,12 @@ public class PBKDF2HashProvider implements HashProvider {
         pseudoRandomFunction = Constants.DEFAULT_PBKDF2_PRF;
         dkLength = Constants.DEFAULT_DERIVED_KEY_LENGTH;
         iterationCount = Constants.DEFAULT_ITERATION_COUNT;
+        try {
+            skf = SecretKeyFactory.getInstance(pseudoRandomFunction);
+        } catch (NoSuchAlgorithmException e) {
+            log.error(String.format(ErrorMessage.ERROR_CODE_NO_SUCH_ALGORITHM.getDescription(), pseudoRandomFunction),
+                    e);
+        }
     }
 
     @Override
@@ -98,8 +104,8 @@ public class PBKDF2HashProvider implements HashProvider {
                 skf = SecretKeyFactory.getInstance(pseudoRandomFunction);
             } catch (NoSuchAlgorithmException e) {
                 if (log.isDebugEnabled()) {
-                    log.debug(pseudoRandomFunction + " " +
-                            ErrorMessage.ERROR_CODE_NO_SUCH_ALGORITHM.getDescription(), e);
+                    log.debug(String.format(ErrorMessage.ERROR_CODE_NO_SUCH_ALGORITHM.getDescription(),
+                            pseudoRandomFunction), e);
                 }
                 throw new HashProviderServerException(pseudoRandomFunction + " " +
                         ErrorMessage.ERROR_CODE_NO_SUCH_ALGORITHM.getDescription(),


### PR DESCRIPTION
The following stack trace was observed when adding a user to a secondary userstore using PBKDF2 as the password hashing algorithm and having **no** hash algorithm properties defined.

```
[2021-07-09 12:44:50,794] [42ec5a73-bbe9-45ea-bad6-352909efba73] ERROR {org.wso2.carbon.user.mgt.UserRealmProxy} - Error while persisting user : ccccc org.wso2.carbon.user.core.UserStoreException: Error while persisting user : ccccc
	at org.wso2.carbon.user.core.common.AbstractUserStoreManager.callSecure(AbstractUserStoreManager.java:228)
	at org.wso2.carbon.user.core.common.AbstractUserStoreManager.addUser(AbstractUserStoreManager.java:4852)
	at org.wso2.carbon.user.mgt.UserRealmProxy.addUser(UserRealmProxy.java:808)
	at org.wso2.carbon.user.mgt.UserAdmin.addUser(UserAdmin.java:202)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.axis2.rpc.receivers.RPCUtil.invokeServiceClass(RPCUtil.java:212)
	at org.apache.axis2.rpc.receivers.RPCMessageReceiver.invokeBusinessLogic(RPCMessageReceiver.java:117)
	at org.apache.axis2.receivers.AbstractInOutMessageReceiver.invokeBusinessLogic(AbstractInOutMessageReceiver.java:40)
	at org.apache.axis2.receivers.AbstractMessageReceiver.receive(AbstractMessageReceiver.java:110)
	at org.apache.axis2.engine.AxisEngine.receive(AxisEngine.java:180)
	at org.apache.axis2.transport.local.LocalTransportReceiver.processMessage(LocalTransportReceiver.java:170)
	at org.apache.axis2.transport.local.LocalTransportReceiver.processMessage(LocalTransportReceiver.java:82)
	at org.wso2.carbon.core.transports.local.CarbonLocalTransportSender.finalizeSendWithToAddress(CarbonLocalTransportSender.java:45)
	at org.apache.axis2.transport.local.LocalTransportSender.invoke(LocalTransportSender.java:77)
	at org.apache.axis2.engine.AxisEngine.send(AxisEngine.java:442)
	at org.apache.axis2.description.OutInAxisOperationClient.send(OutInAxisOperation.java:442)
	at org.apache.axis2.description.OutInAxisOperationClient.executeImpl(OutInAxisOperation.java:228)
	at org.apache.axis2.client.OperationClient.execute(OperationClient.java:149)
	at org.wso2.carbon.user.mgt.stub.UserAdminStub.addUser(UserAdminStub.java:1788)
	at org.wso2.carbon.user.mgt.ui.UserAdminClient.addUser(UserAdminClient.java:94)
	at org.apache.jsp.user.add_002dfinish_002dajaxprocessor_jsp._jspService(add_002dfinish_002dajaxprocessor_jsp.java:211)
	at org.apache.jasper.runtime.HttpJspBase.service(HttpJspBase.java:71)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:741)
	at org.apache.jasper.servlet.JspServletWrapper.service(JspServletWrapper.java:477)
	at org.apache.jasper.servlet.JspServlet.serviceJspFile(JspServlet.java:385)
	at org.apache.jasper.servlet.JspServlet.service(JspServlet.java:329)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:741)
	at org.wso2.carbon.ui.JspServlet.service(JspServlet.java:207)
	at org.wso2.carbon.ui.TilesJspServlet.service(TilesJspServlet.java:80)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:741)
	at org.eclipse.equinox.http.helper.ContextPathServletAdaptor.service(ContextPathServletAdaptor.java:37)
	at org.eclipse.equinox.http.servlet.internal.ServletRegistration.service(ServletRegistration.java:61)
	at org.eclipse.equinox.http.servlet.internal.ProxyServlet.processAlias(ProxyServlet.java:128)
	at org.eclipse.equinox.http.servlet.internal.ProxyServlet.service(ProxyServlet.java:68)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:741)
	at org.wso2.carbon.tomcat.ext.servlet.DelegationServlet.service(DelegationServlet.java:68)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.owasp.csrfguard.CsrfGuardFilter.doFilter(CsrfGuardFilter.java:88)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.catalina.filters.HttpHeaderSecurityFilter.doFilter(HttpHeaderSecurityFilter.java:126)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.wso2.carbon.tomcat.ext.filter.CharacterSetFilter.doFilter(CharacterSetFilter.java:65)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.catalina.filters.HttpHeaderSecurityFilter.doFilter(HttpHeaderSecurityFilter.java:126)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:202)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:541)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:139)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92)
	at org.wso2.carbon.identity.context.rewrite.valve.TenantContextRewriteValve.invoke(TenantContextRewriteValve.java:117)
	at org.wso2.carbon.tomcat.ext.valves.SameSiteCookieValve.invoke(SameSiteCookieValve.java:38)
	at org.wso2.carbon.identity.cors.valve.CORSValve.invoke(CORSValve.java:89)
	at org.wso2.carbon.identity.authz.valve.AuthorizationValve.invoke(AuthorizationValve.java:110)
	at org.wso2.carbon.identity.auth.valve.AuthenticationValve.invoke(AuthenticationValve.java:115)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.continueInvocation(CompositeValve.java:106)
	at org.wso2.carbon.tomcat.ext.valves.TomcatValveContainer.invokeValves(TomcatValveContainer.java:49)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.invoke(CompositeValve.java:67)
	at org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve.invoke(CarbonStuckThreadDetectionValve.java:145)
	at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:690)
	at org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve.invoke(CarbonContextCreatorValve.java:57)
	at org.wso2.carbon.tomcat.ext.valves.RequestEncodingValve.invoke(RequestEncodingValve.java:49)
	at org.wso2.carbon.tomcat.ext.valves.RequestCorrelationIdValve.invoke(RequestCorrelationIdValve.java:126)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:373)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:868)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1590)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.security.PrivilegedActionException: java.lang.reflect.InvocationTargetException
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at org.wso2.carbon.user.core.common.AbstractUserStoreManager.callSecure(AbstractUserStoreManager.java:209)
	... 84 more
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.wso2.carbon.user.core.common.AbstractUserStoreManager$2.run(AbstractUserStoreManager.java:212)
	... 86 more
Caused by: org.wso2.carbon.user.core.UserStoreException: Error while persisting user : ccccc
	at org.wso2.carbon.user.core.jdbc.UniqueIDJDBCUserStoreManager.persistUser(UniqueIDJDBCUserStoreManager.java:1248)
	at org.wso2.carbon.user.core.jdbc.UniqueIDJDBCUserStoreManager.doAddUserWithID(UniqueIDJDBCUserStoreManager.java:1113)
	at org.wso2.carbon.user.core.common.AbstractUserStoreManager.addUser(AbstractUserStoreManager.java:5130)
	at org.wso2.carbon.user.core.common.AbstractUserStoreManager.addUser(AbstractUserStoreManager.java:4886)
	... 91 more
Caused by: java.lang.NullPointerException
	at org.wso2.carbon.hash.provider.pbkdf2.PBKDF2HashProvider.generateHash(PBKDF2HashProvider.java:150)
	at org.wso2.carbon.hash.provider.pbkdf2.PBKDF2HashProvider.calculateHash(PBKDF2HashProvider.java:116)
	at org.wso2.carbon.user.core.jdbc.JDBCUserStoreManager.preparePassword(JDBCUserStoreManager.java:2918)
	at org.wso2.carbon.user.core.jdbc.UniqueIDJDBCUserStoreManager.persistUser(UniqueIDJDBCUserStoreManager.java:1152)
	... 94 more
```