### PR TITLE
Add Client for generate PBKDF2 Hash and the Salt Value for a given plain text password.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <modules>
         <module>components/org.wso2.carbon.identity.hash.provider.pbkdf2</module>
         <module>features/org.wso2.carbon.identity.hash.provider.pbkdf2.server.feature</module>
+        <module>utility/pbkdf2-hash-generator</module>
     </modules>
 
     <dependencyManagement>

--- a/utility/pbkdf2-hash-generator/README.md
+++ b/utility/pbkdf2-hash-generator/README.md
@@ -6,6 +6,7 @@ This contains the Client for generate PBKDF2 Hash and the Salt Value for a given
 1. Clone this repository.
 2. Build this module using `mvn clean install`
 3. Then the executable jar will be built inside the target folder.
+      - `utility/pbkdf2-hash-generator/target/`
 4. Execute the jar using command `java -jar <jar_file.jar>`\
       - ex : `java -jar pbkdf2-hash-generator-0.1.3-SNAPSHOT.jar`
 5. It will prompt you to enter the password. Type the password and press enter.

--- a/utility/pbkdf2-hash-generator/README.md
+++ b/utility/pbkdf2-hash-generator/README.md
@@ -1,0 +1,10 @@
+# pbkdf2-hash-generator
+This contains the Client for generate PBKDF2 Hash and the Salt Value for a given plain text password.
+
+## How to use this Hash Generator
+
+1. Clone this repo.
+2. Build this component using `mvn clean install`
+3. Then run the main method of this java project.
+4. It will prompt you to enter the password. Type the password and press enter.
+5. Then the script will output the Hashed Password and the Salt value.

--- a/utility/pbkdf2-hash-generator/README.md
+++ b/utility/pbkdf2-hash-generator/README.md
@@ -3,8 +3,10 @@ This contains the Client for generate PBKDF2 Hash and the Salt Value for a given
 
 ## How to use this Hash Generator
 
-1. Clone this repo.
-2. Build this component using `mvn clean install`
-3. Then run the main method of this java project.
-4. It will prompt you to enter the password. Type the password and press enter.
-5. Then the script will output the Hashed Password and the Salt value.
+1. Clone this repository.
+2. Build this module using `mvn clean install`
+3. Then the executable jar will be built inside the target folder.
+4. Execute the jar using command `java -jar <jar_file.jar>`\
+      - ex : `java -jar pbkdf2-hash-generator-0.1.3-SNAPSHOT.jar`
+5. It will prompt you to enter the password. Type the password and press enter.
+6. Then the script will output the Hashed Password and the Salt value.

--- a/utility/pbkdf2-hash-generator/pom.xml
+++ b/utility/pbkdf2-hash-generator/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion><build><plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><configuration><source>8</source><target>8</target></configuration></plugin></plugins></build>
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.hash.provider.pbkdf2</groupId>
+        <artifactId>identity-hash-provider-pbkdf2</artifactId>
+        <version>0.1.3-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>pbkdf2-hash-generator</artifactId>
+    <version>0.1.3-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.hash.provider.pbkdf2</groupId>
+            <artifactId>org.wso2.carbon.identity.hash.provider.pbkdf2</artifactId>
+        </dependency>
+    </dependencies>
+    
+</project>

--- a/utility/pbkdf2-hash-generator/pom.xml
+++ b/utility/pbkdf2-hash-generator/pom.xml
@@ -30,7 +30,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pbkdf2-hash-generator</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>Client for generate PBKDF2 Hash and the Salt Value for a given plain text password</description>
 

--- a/utility/pbkdf2-hash-generator/pom.xml
+++ b/utility/pbkdf2-hash-generator/pom.xml
@@ -20,7 +20,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion><build><plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><configuration><source>8</source><target>8</target></configuration></plugin></plugins></build>
 
     <parent>
         <groupId>org.wso2.carbon.identity.hash.provider.pbkdf2</groupId>
@@ -29,8 +28,11 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
+    <modelVersion>4.0.0</modelVersion>
     <artifactId>pbkdf2-hash-generator</artifactId>
     <version>0.1.3-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <description>Client for generate PBKDF2 Hash and the Salt Value for a given plain text password</description>
 
     <dependencies>
         <dependency>
@@ -38,5 +40,38 @@
             <artifactId>org.wso2.carbon.identity.hash.provider.pbkdf2</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven.dependency.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven.jar.plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>dependency/</classpathPrefix>
+                            <mainClass>org.wso2.carbon.identity.utility.hash.generator.pbkdf2.PBKDF2HashGenerator</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     
 </project>

--- a/utility/pbkdf2-hash-generator/src/main/java/hash/generator/pbkdf2/PBKDF2HashGenerator.java
+++ b/utility/pbkdf2-hash-generator/src/main/java/hash/generator/pbkdf2/PBKDF2HashGenerator.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package hash.generator.pbkdf2;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.hash.provider.pbkdf2.PBKDF2HashProvider;
+import org.wso2.carbon.user.core.exceptions.HashProviderException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Scanner;
+
+/**
+ * This class contains the Client for generate PBKDF2 Hash and the Salt Value for a given plain text password.
+ */
+public class PBKDF2HashGenerator {
+
+    private static final Log log = LogFactory.getLog(PBKDF2HashGenerator.class);
+    private static final String SHA_1_PRNG = "SHA1PRNG";
+    private static PBKDF2HashProvider pbkdf2HashProvider;
+
+    public static void main(String[] args) {
+
+        log.info("---Started the Hash generation Script---");
+        pbkdf2HashProvider = getHashProvider();
+        getPasswordFromScanner();
+        log.info("---Hash generation Task Completed---");
+    }
+
+    /**
+     * Get Passwords as a user input from cmd line and print hashed password and salt value.
+     */
+    private static void getPasswordFromScanner() {
+
+        Scanner scanner = new Scanner(System.in, "UTF8");
+
+        while (true) {
+
+            log.info("Enter Password:");
+            //reads password.
+            String originalPassword = scanner.nextLine();
+
+            String generatedSalt = generateSaltValue();
+            byte[] generatedSecuredPasswordHash;
+            try {
+                generatedSecuredPasswordHash = calculateHash(originalPassword.toCharArray(), generatedSalt);
+            } catch (HashProviderException e) {
+                log.error(e);
+                break;
+            }
+            String strongPassword = bytesToBase64(generatedSecuredPasswordHash);
+
+            log.info("Hashed Password:" + strongPassword);
+            log.info("Salt Value:" + generatedSalt);
+            log.info("----------------------------------");
+        }
+    }
+
+    /**
+     * This private method used to create a PBKDF2HashProvider instance.
+     *
+     * @return pbkdf2HashProvider which is used to generate hash values.
+     */
+    private static PBKDF2HashProvider getHashProvider() {
+
+        PBKDF2HashProvider pbkdf2HashProvider = new PBKDF2HashProvider();
+        pbkdf2HashProvider.init();
+        return pbkdf2HashProvider;
+    }
+
+    /**
+     * Generate hash password for the given plain password and salt value.
+     *
+     * @param plainText The plain text value to be hashed.
+     * @param salt      The salt value.
+     * @return The resulting hash value of the value.
+     */
+    private static byte[] calculateHash(char[] plainText, String salt) throws HashProviderException {
+
+        return pbkdf2HashProvider.calculateHash(plainText, salt);
+    }
+
+    /**
+     * This private method returns a saltValue using SecureRandom.
+     *
+     * @return saltValue.
+     */
+    private static String generateSaltValue() throws RuntimeException {
+
+        try {
+            SecureRandom secureRandom = SecureRandom.getInstance(SHA_1_PRNG);
+            byte[] bytes = new byte[16];
+            //secureRandom is automatically seeded by calling nextBytes
+            secureRandom.nextBytes(bytes);
+            return bytesToBase64(bytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA1PRNG algorithm could not be found.");
+        }
+    }
+
+    /**
+     * This method is responsible for converting the byte array of salt to a base64 string value.
+     *
+     * @param bytes The byte array.
+     * @return The converted base64 string value from byte array.
+     */
+    private static String bytesToBase64(byte[] bytes) {
+
+        byte[] byteArray = Base64.getEncoder().encode(bytes);
+        return (new String(byteArray, StandardCharsets.UTF_8));
+    }
+}

--- a/utility/pbkdf2-hash-generator/src/main/java/org/wso2/carbon/identity/utility/hash/generator/pbkdf2/PBKDF2HashGenerator.java
+++ b/utility/pbkdf2-hash-generator/src/main/java/org/wso2/carbon/identity/utility/hash/generator/pbkdf2/PBKDF2HashGenerator.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package hash.generator.pbkdf2;
+package org.wso2.carbon.identity.utility.hash.generator.pbkdf2;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/utility/pbkdf2-hash-generator/src/main/java/org/wso2/carbon/identity/utility/hash/generator/pbkdf2/PBKDF2HashGenerator.java
+++ b/utility/pbkdf2-hash-generator/src/main/java/org/wso2/carbon/identity/utility/hash/generator/pbkdf2/PBKDF2HashGenerator.java
@@ -41,7 +41,7 @@ public class PBKDF2HashGenerator {
     public static void main(String[] args) {
 
         log.info("---Started the Hash generation Script---");
-        pbkdf2HashProvider = getHashProvider();
+        initHashProvider();
         getPasswordFromScanner();
         log.info("---Hash generation Task Completed---");
     }
@@ -76,15 +76,12 @@ public class PBKDF2HashGenerator {
     }
 
     /**
-     * This private method used to create a PBKDF2HashProvider instance.
-     *
-     * @return pbkdf2HashProvider which is used to generate hash values.
+     * This method used to initialize the PBKDF2HashProvider instance.
      */
-    private static PBKDF2HashProvider getHashProvider() {
+    private static void initHashProvider() {
 
-        PBKDF2HashProvider pbkdf2HashProvider = new PBKDF2HashProvider();
+        pbkdf2HashProvider = new PBKDF2HashProvider();
         pbkdf2HashProvider.init();
-        return pbkdf2HashProvider;
     }
 
     /**


### PR DESCRIPTION
### Purpose
Add Client for generate PBKDF2 Hash and the Salt Value for a given plain text password.

### How to Use
Any one can use this client to generate PBKDF2 hash and Salt Value by providing plain text password. The ReadMe contains the instructions to use this generator.