### PR TITLE
Change log level for bundle activation from INFO to DEBUG

### DIFF
--- a/components/org.wso2.carbon.identity.hash.provider.pbkdf2/src/main/java/org/wso2/carbon/identity/hash/provider/pbkdf2/internal/PBKDF2HashServiceComponent.java
+++ b/components/org.wso2.carbon.identity.hash.provider.pbkdf2/src/main/java/org/wso2/carbon/identity/hash/provider/pbkdf2/internal/PBKDF2HashServiceComponent.java
@@ -44,7 +44,10 @@ public class PBKDF2HashServiceComponent {
         HashProviderFactory hashProviderFactory = new PBKDF2HashProviderFactory();
         ctxt.getBundleContext().registerService(HashProviderFactory.class.getName(),
                 hashProviderFactory, null);
-        log.info("PBKDF2 bundle activated successfully.");
+                
+        if (log.isDebugEnabled()) {
+            log.debug("PBKDF2 bundle activated successfully.");
+        }
     }
 
     @Deactivate


### PR DESCRIPTION
Modify the logging behavior in the PBKDF2 bundle activation process to only log when debug is enabled.

Related to,

* https://github.com/wso2/product-is/issues/20708